### PR TITLE
Ensured that the valid word check works correctly

### DIFF
--- a/WordMania/Pages/Index.razor.cs
+++ b/WordMania/Pages/Index.razor.cs
@@ -211,6 +211,10 @@
         {
             // load the words from the text file into a string
             var wordsString = await Http.GetStringAsync("words.txt");
+
+            //Removes all \r tags read in from the words text file
+            wordsString = wordsString.Replace("\r", string.Empty); 
+
             // convert to string array
             AllWords = wordsString.Split("\n");
             // set up a new game


### PR DESCRIPTION
Hi

Can you please review this fix which ensures that the valid word check works correctly?

Currently when the user enters a valid word then the "not a real word" error is displayed.  Found that the reason was that there are "\r" tags as well as "\n" tags when the list of valid words is read from the words.txt text file.  This pull request ensures that the list of words is split using a combination of "\r\n".

![image](https://user-images.githubusercontent.com/33494306/152836084-be0c33ce-7120-476f-a760-22ee9fdd22e2.png)

Thanks
John